### PR TITLE
Add AArch64/ARM64 job on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ matrix:
       -DJAEGERTRACING_PLUGIN=ON -DBUILD_TESTING=ON -DHUNTER_CONFIGURATION_TYPES=Release'"
 before_install:
 - eval "${MATRIX_EVAL}"
+- echo "CPU is- ${TRAVIS_CPU_ARCH}"
 - |
   if [ "${TRAVIS_CPU_ARCH}" = "aarch64" ]; then
     sudo snap install cmake --classic;

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,6 @@ matrix:
       -DJAEGERTRACING_PLUGIN=ON -DBUILD_TESTING=ON -DHUNTER_CONFIGURATION_TYPES=Release'"
 before_install:
 - eval "${MATRIX_EVAL}"
-- echo "CPU is- ${TRAVIS_CPU_ARCH}"
 - |
   if [ "${TRAVIS_CPU_ARCH}" = "arm64" ]; then
     sudo snap install cmake --classic;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,31 @@ matrix:
     - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug
       -DBUILD_SHARED_LIBS=ON -DJAEGERTRACING_COVERAGE=ON'"
   - os: linux
+    dist: xenial
+    arch: arm64
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *1
+        - g++-4.9
+    env:
+    - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug
+      -DBUILD_SHARED_LIBS=ON -DJAEGERTRACING_COVERAGE=ON'"
+  - os: linux
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *1
+        - g++-5
+    env:
+    - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug
+      -DBUILD_SHARED_LIBS=ON -DJAEGERTRACING_COVERAGE=ON'"
+  - os: linux
+    arch: arm64
     addons:
       apt:
         sources:
@@ -41,6 +66,30 @@ matrix:
     - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug
       -DBUILD_SHARED_LIBS=ON -DJAEGERTRACING_COVERAGE=ON'"
   - os: linux
+    arch: arm64
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *1
+        - g++-6
+    env:
+    - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug
+      -DBUILD_SHARED_LIBS=ON -DJAEGERTRACING_COVERAGE=ON'"
+  - os: linux
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *1
+        - g++-7
+    env:
+    - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Debug
+      -DBUILD_SHARED_LIBS=ON -DJAEGERTRACING_COVERAGE=ON'"
+  - os: linux
+    arch: arm64
     addons:
       apt:
         sources:
@@ -62,10 +111,27 @@ matrix:
     env:
     - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Release
       -DJAEGERTRACING_PLUGIN=ON -DBUILD_TESTING=ON -DHUNTER_CONFIGURATION_TYPES=Release'"
+  - os: linux
+    arch: arm64
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *1
+        - g++-7
+    env:
+    - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_OPTIONS='-DCMAKE_BUILD_TYPE=Release
+      -DJAEGERTRACING_PLUGIN=ON -DBUILD_TESTING=ON -DHUNTER_CONFIGURATION_TYPES=Release'"
 before_install:
 - eval "${MATRIX_EVAL}"
-- mkdir cmake-download && cd cmake-download && curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh
-  && bash cmake-3.10.0-rc5-Linux-x86_64.sh --skip-license && cd ..
+- |
+  if [ "${TRAVIS_CPU_ARCH}" = "aarch64" ]; then
+    sudo snap install cmake --classic;
+    export PATH=/snap/bin:$PATH;
+  else
+    mkdir cmake-download && cd cmake-download && curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh && bash cmake-3.10.0-rc5-Linux-x86_64.sh --skip-license && cd ..;
+  fi
 script:
 - CMAKE_OPTIONS="${CMAKE_OPTIONS}" ./scripts/build.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ before_install:
 - eval "${MATRIX_EVAL}"
 - echo "CPU is- ${TRAVIS_CPU_ARCH}"
 - |
-  if [ "${TRAVIS_CPU_ARCH}" = "aarch64" ]; then
+  if [ "${TRAVIS_CPU_ARCH}" = "arm64" ]; then
     sudo snap install cmake --classic;
     export PATH=/snap/bin:$PATH;
   else


### PR DESCRIPTION
Package Owner: Madhukar

PR change Details: Added travis-ci/arm64 support for CI/CD aarch64.

Testing Detail :
Done testing. Below is the link for build logs: https://travis-ci.com/github/odidev/jaeger-client-cpp

Peer Reviewer: Pruthvi, Shobhit